### PR TITLE
Add mininmum release age for npm packages

### DIFF
--- a/openatlas/static/.npmrc
+++ b/openatlas/static/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
This PR adds a minimum release age for npm packages using [npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc) (currently set to 3 days).